### PR TITLE
feat: improve mobile layout and hud responsiveness

### DIFF
--- a/gintama-genius-web/src/App.css
+++ b/gintama-genius-web/src/App.css
@@ -125,47 +125,72 @@ select:focus-visible {
 /* Mobile Adjustments */
 @media (max-width: 600px) {
     .menu-container {
-        padding: 1.5rem;
-        width: 85vw;
+        padding: 1rem;
+        width: 90vw;
     }
 
     .menu-title {
-        font-size: 1.5rem;
+        font-size: 1.4rem;
     }
 
     .hud-header {
-        padding: 0.5rem;
-        font-size: 0.8rem;
+        padding: 0.4rem;
+        font-size: 0.75rem;
+        gap: 0.3rem;
     }
 
     .hud-item {
-        padding: 0.3rem 0.6rem;
+        padding: 0.2rem 0.4rem;
+        gap: 0.3rem;
+        white-space: nowrap;
+    }
+
+    .hud-item svg {
+        width: 16px;
+        height: 16px;
     }
 
     .hud-value {
-        font-size: 0.9rem;
+        font-size: 0.8rem;
+    }
+
+    .hud-value-small {
+        font-size: 0.7rem;
     }
 
     .game-over-content {
-      padding: 1.5rem;
+      padding: 1.2rem;
     }
 
     .debug-panel {
-      top: 44px;
-      right: 8px;
+      top: 40px;
+      right: 4px;
+    }
+
+    .game-layout {
+        gap: 0.5rem;
+        padding: 0.5rem 0;
+    }
+
+    .indicator-area {
+        min-height: 32px;
     }
 }
 
 /* Short screens */
 @media (max-height: 650px) {
     .menu-container {
-        padding: 1rem;
+        padding: 0.8rem;
     }
     .splash-image {
-        max-height: 100px;
+        max-height: 80px;
     }
     .game-layout {
-        gap: 0.5rem;
+        gap: 0.2rem;
+        padding: 0.2rem 0;
+    }
+    .hud-header {
+        padding: 0.3rem;
     }
 }
 

--- a/gintama-genius-web/src/components/hud/FeedbackOverlay.tsx
+++ b/gintama-genius-web/src/components/hud/FeedbackOverlay.tsx
@@ -84,11 +84,11 @@ export const FeedbackOverlay: React.FC<FeedbackOverlayProps> = ({ feedback, stre
             type: "spring",
             stiffness: 400,
             damping: 15,
-            rotate: { duration: 0.5 }
+            rotate: { duration: 0.3 }
           }}
           style={{
             position: 'absolute',
-            top: '40%',
+            top: '15%',
             left: 0,
             right: 0,
             display: 'flex',

--- a/gintama-genius-web/src/components/hud/NewRoundBanner.tsx
+++ b/gintama-genius-web/src/components/hud/NewRoundBanner.tsx
@@ -20,7 +20,7 @@ export const NewRoundBanner: React.FC<NewRoundBannerProps> = ({ feedback }) => {
           transition={{ type: "spring", stiffness: 100, damping: 20 }}
           style={{
             position: 'absolute',
-            top: '40%',
+            top: '20%',
             left: 0,
             right: 0,
             textAlign: 'center',

--- a/gintama-genius-web/src/components/hud/UrgentIndicator.tsx
+++ b/gintama-genius-web/src/components/hud/UrgentIndicator.tsx
@@ -28,8 +28,8 @@ export const UrgentIndicator: React.FC<UrgentIndicatorProps> = ({ visible }) => 
 
             {/* Pulsing Border Effect on Screen */}
             <motion.div
-                animate={{ boxShadow: ['inset 0 0 0px #ff0000', 'inset 0 0 50px #ff0000', 'inset 0 0 0px #ff0000'] }}
-                transition={{ duration: 0.8, repeat: Infinity }}
+                animate={{ boxShadow: ['inset 0 0 0px #ff0000', 'inset 0 0 80px #ff0000', 'inset 0 0 0px #ff0000'] }}
+                transition={{ duration: 0.4, repeat: Infinity }}
                 style={{
                     position: 'fixed',
                     top: 0, left: 0, right: 0, bottom: 0,

--- a/gintama-genius-web/src/styles/hud.css
+++ b/gintama-genius-web/src/styles/hud.css
@@ -54,7 +54,7 @@
     align-items: center;
     width: 100%;
     margin-top: auto;
-    padding-bottom: env(safe-area-inset-bottom, 2rem);
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
     gap: 1rem;
     z-index: 20;
 }


### PR DESCRIPTION
This PR addresses the user's request to improve the mobile layout and enhance the fun/surprising factor of the game's HUDs. 

Changes include:
- Fixed a major layout bug where header elements (like level and difficulty) wrapped and got cut off on narrow screens.
- Relocated the FeedbackOverlay (hits/misses/combos) and NewRoundBanner to sit higher on the screen so they don't block the actual game buttons during intense mobile gameplay.
- Increased the animation speed and intensity of the `UrgentIndicator` (the "CORRA!" screen border pulse) to heighten the suspense.
- Tweaked `framer-motion` properties on the feedback popups for a snappier response.
- Verified visual changes via Playwright screenshots using an iPhone SE viewport.

---
*PR created automatically by Jules for task [482937609530273849](https://jules.google.com/task/482937609530273849) started by @juninmd*